### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+node_modules
+output
+.env
+*.md
+src/client/.next

--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,7 @@ SECRET_KEY = a_random_secret_key
 USER_PASSWORD = password
 ADMIN_PASSWORD = p@ssw0rd!
 VIDEOS_PATH = /path/to/videos
+
+# Docker only: host path to your video library (mounted as /videos inside the container)
+HOST_VIDEOS_PATH = /path/to/videos
+

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ VIDEOS_PATH = /path/to/videos
 HOST_VIDEOS_PATH = /path/to/videos
 
 # Optional: poll for new/deleted video files every N milliseconds instead of using fs.watch
-# Recommended when running in Docker (set in docker-compose.yml by default)
+# Recommended when videos are on a network share (NFS, SMB) or running in Docker,
+# as inotify events don't work reliably in those environments.
+# (Docker sets this automatically via docker-compose.yml)
 # WATCH_POLLING = 10000
 

--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,7 @@ VIDEOS_PATH = /path/to/videos
 # Docker only: host path to your video library (mounted as /videos inside the container)
 HOST_VIDEOS_PATH = /path/to/videos
 
+# Optional: poll for new/deleted video files every N milliseconds instead of using fs.watch
+# Recommended when running in Docker (set in docker-compose.yml by default)
+# WATCH_POLLING = 10000
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docker-entrypoint.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:20-alpine AS builder
 
+RUN apk add --no-cache openssl
+
 WORKDIR /app
 
 COPY package*.json ./
@@ -14,6 +16,8 @@ RUN npm run build
 
 # ---- Runner ----
 FROM node:20-alpine AS runner
+
+RUN apk add --no-cache openssl
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+COPY prisma ./prisma/
+
+RUN npm ci
+
+COPY . .
+
+# Build the Next.js client
+RUN npm run build
+
+# ---- Runner ----
+FROM node:20-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# Copy node_modules (includes tsx, ffmpeg packages, prisma client, etc.)
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package*.json ./
+
+# Copy source (server runs TypeScript directly via tsx)
+COPY --from=builder /app/src ./src
+COPY --from=builder /app/prisma ./prisma
+
+# Copy Next.js build output
+COPY --from=builder /app/src/client/.next ./src/client/.next
+
+# Copy Next.js config files needed at runtime
+COPY --from=builder /app/postcss.config.mjs ./
+COPY --from=builder /app/tailwind.config.ts ./
+
+COPY docker-entrypoint.sh ./
+RUN chmod +x docker-entrypoint.sh
+
+EXPOSE 3000
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -31,13 +31,25 @@ The app is meant for use in private groups, with a no-account system, using a si
 
 ## Setup
 
-To get the application running on a server, follow the steps below.
+### Docker (recommended)
 
-1. Install [Node.js](https://nodejs.org/en) >= v20
-2. Download the source code either manually, or with `git clone https://github.com/Voy7/SlopToob.git`.
-3. Create a `.env` file in the root of the project, this will hold some important options. You can copy the `.env.example` file, which has all the variables listed for you.
-4. For the first time, you must `npm run build` in the root of the project.
-5. Then run `npm start` to start the app!
+Requires [Docker](https://docs.docker.com/get-docker/) with the Compose plugin.
+
+1. Clone the repo: `git clone https://github.com/Voy7/SlopToob.git`
+2. Copy `.env.example` to `.env` and fill in your values.
+3. Set `HOST_VIDEOS_PATH` in `.env` to the path of your video library on the host machine.
+4. Run `docker compose up --build -d`
+
+The app will be available at the `SERVER_URL` you configured. The database, transcoded files, and thumbnails are stored in a named Docker volume (`sloptoob-output`) so they persist across restarts and rebuilds.
+
+### Manual
+
+Requires [Node.js](https://nodejs.org/en) >= v20.
+
+1. Clone the repo: `git clone https://github.com/Voy7/SlopToob.git`
+2. Copy `.env.example` to `.env` and fill in your values.
+3. Run `npm run build` to build the Next.js client.
+4. Run `npm start` to start the app.
 
 ## Technical Details
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  sloptoob:
+    build: .
+    ports:
+      - "${SERVER_PORT:-3000}:3000"
+    env_file:
+      - .env
+    environment:
+      # Override VIDEOS_PATH to the in-container mount point
+      VIDEOS_PATH: /videos
+    volumes:
+      # Set HOST_VIDEOS_PATH in your .env to the path of your video library on the host
+      - ${HOST_VIDEOS_PATH}:/videos:ro
+      # Persist database, transcoded files, thumbnails, etc.
+      - sloptoob-output:/app/output
+    restart: unless-stopped
+
+volumes:
+  sloptoob-output:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     environment:
       # Override VIDEOS_PATH to the in-container mount point
       VIDEOS_PATH: /videos
+      # Poll for new/deleted files every 10s (fs.watch doesn't work reliably with Docker bind mounts)
+      WATCH_POLLING: 10000
     volumes:
       # Set HOST_VIDEOS_PATH in your .env to the path of your video library on the host
       - ${HOST_VIDEOS_PATH}:/videos:ro

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# Run database migrations on every startup
+echo "Running database migrations..."
+npx prisma migrate deploy
+
+# Start the app
+exec npm start

--- a/src/server/core/EnvVariables.ts
+++ b/src/server/core/EnvVariables.ts
@@ -30,6 +30,8 @@ class EnvVariables {
   readonly THUMBNAILS_OUTPUT_PATH = parsePath(env?.OUTPUT_PATH, 'output', 'thumbnails')
   readonly VIDEO_LOGGER_OUTPUT_PATH = parsePath(env?.OUTPUT_PATH, 'output', 'video-logs')
   readonly DEV_FILE_TREE_TEST = env?.FILE_TREE_TEST === 'true'
+  // Polling interval in ms for file watching (0 = use native fs.watch instead)
+  readonly WATCH_POLLING = parseInt(env?.WATCH_POLLING || '0') || 0
 }
 
 export default new EnvVariables()

--- a/src/server/core/EnvVariables.ts
+++ b/src/server/core/EnvVariables.ts
@@ -1,7 +1,9 @@
 import dotenv from 'dotenv'
 import path from 'path'
 
-const { parsed: env } = dotenv.config()
+// Load .env file into process.env if present (no-op if file doesn't exist)
+dotenv.config()
+
 const dirname = path.resolve()
 
 // Properly parse path variables, and return default if undefined
@@ -17,21 +19,21 @@ function parsePath(envPath: string | undefined, defaultPath: string, additional?
 
 // All project's environment variables
 class EnvVariables {
-  readonly PROJECT_MODE = process.env?.NODE_ENV || 'development'
-  readonly SERVER_URL = env?.SERVER_URL || 'http://localhost'
-  readonly SERVER_PORT = parseInt(env?.SERVER_PORT || '3000') || 3000
-  readonly SECRET_KEY = env?.SECRET_KEY || 'secret'
-  readonly USER_PASSWORD = env?.USER_PASSWORD || 'user'
-  readonly ADMIN_PASSWORD = env?.ADMIN_PASSWORD || 'admin'
-  readonly VIDEOS_PATH = parsePath(env?.VIDEOS_PATH, '/videos')
-  readonly VIDEOS_OUTPUT_PATH = parsePath(env?.OUTPUT_PATH, 'output', 'videos-transcoded')
-  readonly BUMPERS_PATH = parsePath(env?.OUTPUT_PATH, 'output', 'bumpers')
-  readonly BUMPERS_OUTPUT_PATH = parsePath(env?.OUTPUT_PATH, 'output', 'bumpers-transcoded')
-  readonly THUMBNAILS_OUTPUT_PATH = parsePath(env?.OUTPUT_PATH, 'output', 'thumbnails')
-  readonly VIDEO_LOGGER_OUTPUT_PATH = parsePath(env?.OUTPUT_PATH, 'output', 'video-logs')
-  readonly DEV_FILE_TREE_TEST = env?.FILE_TREE_TEST === 'true'
+  readonly PROJECT_MODE = process.env.NODE_ENV || 'development'
+  readonly SERVER_URL = process.env.SERVER_URL || 'http://localhost'
+  readonly SERVER_PORT = parseInt(process.env.SERVER_PORT || '3000') || 3000
+  readonly SECRET_KEY = process.env.SECRET_KEY || 'secret'
+  readonly USER_PASSWORD = process.env.USER_PASSWORD || 'user'
+  readonly ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'admin'
+  readonly VIDEOS_PATH = parsePath(process.env.VIDEOS_PATH, '/videos')
+  readonly VIDEOS_OUTPUT_PATH = parsePath(process.env.OUTPUT_PATH, 'output', 'videos-transcoded')
+  readonly BUMPERS_PATH = parsePath(process.env.OUTPUT_PATH, 'output', 'bumpers')
+  readonly BUMPERS_OUTPUT_PATH = parsePath(process.env.OUTPUT_PATH, 'output', 'bumpers-transcoded')
+  readonly THUMBNAILS_OUTPUT_PATH = parsePath(process.env.OUTPUT_PATH, 'output', 'thumbnails')
+  readonly VIDEO_LOGGER_OUTPUT_PATH = parsePath(process.env.OUTPUT_PATH, 'output', 'video-logs')
+  readonly DEV_FILE_TREE_TEST = process.env.FILE_TREE_TEST === 'true'
   // Polling interval in ms for file watching (0 = use native fs.watch instead)
-  readonly WATCH_POLLING = parseInt(env?.WATCH_POLLING || '0') || 0
+  readonly WATCH_POLLING = parseInt(process.env.WATCH_POLLING || '0') || 0
 }
 
 export default new EnvVariables()
@@ -41,12 +43,12 @@ export async function checkRequiredVariables() {
 
   const missing: string[] = []
 
-  if (!env?.SERVER_URL) missing.push('SERVER_URL')
-  if (!env?.SERVER_PORT) missing.push('SERVER_PORT')
-  if (!env?.SECRET_KEY) missing.push('SECRET_KEY')
-  if (!env?.USER_PASSWORD) missing.push('USER_PASSWORD')
-  if (!env?.ADMIN_PASSWORD) missing.push('ADMIN_PASSWORD')
-  if (!env?.VIDEOS_PATH) missing.push('VIDEOS_PATH')
+  if (!process.env.SERVER_URL) missing.push('SERVER_URL')
+  if (!process.env.SERVER_PORT) missing.push('SERVER_PORT')
+  if (!process.env.SECRET_KEY) missing.push('SECRET_KEY')
+  if (!process.env.USER_PASSWORD) missing.push('USER_PASSWORD')
+  if (!process.env.ADMIN_PASSWORD) missing.push('ADMIN_PASSWORD')
+  if (!process.env.VIDEOS_PATH) missing.push('VIDEOS_PATH')
 
   // If any required variables are missing, fail the check
   if (missing.length) {

--- a/src/server/core/FsWatcher.ts
+++ b/src/server/core/FsWatcher.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import Logger from '@/server/core/Logger'
+import Env from '@/server/core/EnvVariables'
 
 // Utility to watch directory and emit added & deleted files events
 export default class FsWatcher {
@@ -12,10 +13,40 @@ export default class FsWatcher {
     this.dirPath = dirPath
   }
 
+  // Poll the directory on an interval and emit add/delete events on changes
+  private async startPolling(intervalMs: number) {
+    let knownFiles = new Set(await this.crawlDirectory(this.dirPath))
+
+    setInterval(async () => {
+      try {
+        const currentFiles = await this.crawlDirectory(this.dirPath)
+        const currentSet = new Set(currentFiles)
+
+        for (const file of currentFiles) {
+          if (!knownFiles.has(file)) this.newFileCallback?.(file)
+        }
+
+        for (const file of knownFiles) {
+          if (!currentSet.has(file)) this.deleteFileCallback?.(file)
+        }
+
+        knownFiles = currentSet
+      } catch (error) {
+        Logger.error('[FsWatcher] Polling error:', error)
+      }
+    }, intervalMs)
+  }
+
   // Start watching directory, run this after event listeners are set
   activate() {
     if (this.isActive) return
     this.isActive = true
+
+    if (Env.WATCH_POLLING > 0) {
+      Logger.debug(`[FsWatcher] Using polling mode (interval: ${Env.WATCH_POLLING}ms)`)
+      this.startPolling(Env.WATCH_POLLING)
+      return
+    }
 
     fs.watch(this.dirPath, { recursive: true }, async (event, filename) => {
       // console.log(filename, event)


### PR DESCRIPTION
## Summary

- Adds `Dockerfile`, `docker-compose.yml`, `docker-entrypoint.sh`, and `.dockerignore` to run the app in a container
- Runs `prisma migrate deploy` automatically on startup via the entrypoint script
- Adds a `WATCH_POLLING` env var that switches file watching from `fs.watch` (inotify) to interval-based polling — fixes new files not being detected on Docker bind mounts and NFS shares
- Updates README with Docker and manual setup instructions

## Test plan

- [ ] `docker compose up --build -d` starts the app successfully
- [ ] Database migrations apply on first boot
- [ ] App reads env vars from `docker-compose.yml` environment section (no `.env` file required inside container)
- [ ] Videos mounted via `HOST_VIDEOS_PATH` appear in the file picker
- [ ] New files added to the mounted volume are detected within `WATCH_POLLING` ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)