### PR TITLE
Add Docker support

### DIFF
--- a/src/server/core/Checklist.ts
+++ b/src/server/core/Checklist.ts
@@ -82,10 +82,17 @@ if (canPrint) {
         .map((check) => `  ○ `.gray + check.padEnd(MAX_CHECK_LENGTH, ' ') + ' | '.gray)
         .join('\n')}\n\n\n`
     )
+} else {
+  console.log(`
+  ${HEADER_MSG}
+`)
 }
 
 function updateCheckLine(check: CheckKey, text: string) {
-  if (!canPrint) return
+  if (!canPrint) {
+    console.log(text)
+    return
+  }
   const index = Object.keys(CHECKS).indexOf(check)
   process.stdout.write('\u001b[s')
   // clear line
@@ -123,7 +130,10 @@ let loadingInterval = setInterval(() => {
 
 function printStatus(message: string) {
   clearInterval(loadingInterval)
-  if (!canPrint) return
+  if (!canPrint) {
+    console.log(`  ${message}`)
+    return
+  }
   process.stdout.write('\u001b[s')
   process.stdout.cursorTo(0, STATUS_LINE)
   process.stdout.write(' '.repeat(100)) // Clear line


### PR DESCRIPTION
## Summary

- Adds `Dockerfile`, `docker-compose.yml`, and `docker-entrypoint.sh` to run SlopToob in a container
- Installs OpenSSL in the Docker image so Prisma can connect to the SQLite database
- Fixes environment variables not being read when injected by Docker (dotenv + proper env var sourcing)
- Adds a polling fallback for file watching (`WATCH_POLLING` env var) for NFS/Docker volume mounts where native `fs.watch` is unreliable
- Forces LF line endings on `docker-entrypoint.sh` so it runs correctly in Linux containers
- Falls back to plain `console.log` output for startup checks when stdout is not a TTY (e.g. `docker logs`), so the server is no longer silent in Docker

## Test plan

- [ ] `docker compose up` starts the container and shows startup check output in logs
- [ ] Environment variables passed via `docker-compose.yml` are picked up correctly
- [ ] Prisma migrations run without OpenSSL errors
- [ ] File watching works on Docker volume mounts (with and without `WATCH_POLLING`)
- [ ] Server is accessible at the configured `SERVER_URL`/`SERVER_PORT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)